### PR TITLE
(WIP) Refactor prepared EventStateMachine design

### DIFF
--- a/src/ClassLibrary/Class/DesignPatternInterface/IObserver.cs
+++ b/src/ClassLibrary/Class/DesignPatternInterface/IObserver.cs
@@ -1,0 +1,4 @@
+public interface IObserver
+{
+    public void Update();
+}

--- a/src/ClassLibrary/Class/DesignPatternInterface/IRegister.cs
+++ b/src/ClassLibrary/Class/DesignPatternInterface/IRegister.cs
@@ -1,0 +1,4 @@
+public interface IRegister
+{
+    public void Register(IObserver observer);
+}

--- a/src/ClassLibrary/Class/Event/ActionState.cs
+++ b/src/ClassLibrary/Class/Event/ActionState.cs
@@ -1,0 +1,8 @@
+public enum ActionState
+{
+    Idle,
+    RollingDice,
+    ProcessingDouble,
+    GoingToJail,
+    MovingByRollingDiceResultTotal
+}

--- a/src/ClassLibrary/Class/Event/EventState.cs
+++ b/src/ClassLibrary/Class/Event/EventState.cs
@@ -1,0 +1,10 @@
+public enum EventState
+{
+    NormalMovingTurn,
+    JailTurn,
+    Auction,
+    LandEvent,
+    BuildHouse,
+    Trade,
+    EndTurn
+}

--- a/src/ClassLibrary/Class/Event/EventStateMachine.cs
+++ b/src/ClassLibrary/Class/Event/EventStateMachine.cs
@@ -1,0 +1,18 @@
+public class EventStateMachine : IObserver
+{
+    protected EventState myEventState;
+    protected EventStatesConnector eventStatesConnector;
+    public EventStateMachine(EventStatesConnector eventStatesConnector)
+    {
+        this.eventStatesConnector = eventStatesConnector;
+        this.eventStatesConnector.Register(this);
+    }
+    public void Update()
+    {
+        if (this.myEventState == eventStatesConnector.CurrentEventState)
+        {
+            TransitionFromIdle();
+        }
+    }
+    protected virtual void TransitionFromIdle(){}
+}

--- a/src/ClassLibrary/Class/Event/EventStatesConnector.cs
+++ b/src/ClassLibrary/Class/Event/EventStatesConnector.cs
@@ -1,0 +1,27 @@
+public class EventStatesConnector : IRegister
+{
+    public EventState CurrentEventState 
+    {
+        get
+        {
+            return this.CurrentEventState;
+        }
+        set
+        {
+            this.CurrentEventState = value;
+            this.Notify();
+        }
+    }
+    private List<IObserver> EventStateMachines = new List<IObserver> ();
+    public void Register(IObserver eventStateMachine)
+    {
+        EventStateMachines.Add(eventStateMachine);
+    }
+    private void Notify()
+    {
+        foreach (var eventStateMachine in EventStateMachines)
+        {
+            eventStateMachine.Update();
+        }
+    }
+}

--- a/src/ClassLibrary/Class/Event/Interface/ICurrentActionStateDistributor.cs
+++ b/src/ClassLibrary/Class/Event/Interface/ICurrentActionStateDistributor.cs
@@ -1,0 +1,4 @@
+public interface ICurrentActionStateDistributor : IRegister
+{
+    public ActionState CurrentState{ get; }
+}

--- a/src/ClassLibrary/Class/Event/NormalMovingTurnStateMachine.cs
+++ b/src/ClassLibrary/Class/Event/NormalMovingTurnStateMachine.cs
@@ -1,0 +1,112 @@
+public class NormalMovingTurn : EventStateMachine, ITrigger, ICurrentActionStateDistributor
+{
+    private ActionState currentActionState = ActionState.Idle;
+    private List<IObserver> observers = new List<IObserver>();
+
+    public NormalMovingTurn(EventStatesConnector sharedCurrentEventState)
+        :base(sharedCurrentEventState)
+    {
+    }
+
+    public bool IsReadyToTransition
+    {
+        get
+        {
+            return this.IsReadyToTransition;
+        }
+        set
+        {
+            this.IsReadyToTransition = value;
+            if (this.IsReadyToTransition)
+            {
+                switch (this.currentActionState)
+                {
+                    case ActionState.RollingDice:
+                        this.TransitionFromRollingDice();
+                        break;
+                    case ActionState.GoingToJail:
+                        this.TransitionFromGoingToJail();
+                        break;
+                    case ActionState.MovingByRollingDiceResultTotal:
+                        
+                        break;
+                    default:
+                        throw new Exception("There is a missed state");
+                }
+            }
+        }
+    }
+    public ActionState CurrentState 
+    {
+        get
+        {
+            return this.currentActionState;
+        }
+        protected set
+        {
+            this.currentActionState = value;
+            foreach (var observer in this.observers)
+            {
+                observer.Update();
+            }
+        }
+    }
+
+    public bool RolledDouble { get => this.RolledDouble; set => RolledDouble = value; }
+    public bool RolledDouble3TimesInRow { get => this.RolledDouble3TimesInRow; set => this.RolledDouble3TimesInRow = value; }
+
+
+    public void Register(IObserver observer)
+    {
+        this.observers.Add(observer);
+    }
+
+    protected override void TransitionFromIdle()
+    {
+        this.CurrentState = ActionState.RollingDice;
+    }
+
+    private void TransitionFromRollingDice()
+    {
+        if (this.RolledDouble)
+        {
+            this.CurrentState = ActionState.ProcessingDouble;
+        }
+        else
+        {
+            this.CurrentState = ActionState.MovingByRollingDiceResultTotal;
+        }
+    }
+
+    private void TransitionFromProcessingDouble()
+    {
+        if (this.RolledDouble3TimesInRow)
+        {
+            this.CurrentState = ActionState.GoingToJail;
+        }
+        else
+        {
+            this.CurrentState = ActionState.MovingByRollingDiceResultTotal;
+        }
+    }
+
+    private void TransitionFromGoingToJail()
+    {
+        this.CurrentState = ActionState.Idle;
+        this.eventStatesConnector.CurrentEventState = EventState.EndTurn;
+    }
+    private void TransitionFromMovingByRollDiceResultTotal()
+    {
+        this.CurrentState = ActionState.Idle;
+        this.eventStatesConnector.CurrentEventState = EventState.LandEvent;
+    }
+}
+
+public interface ITrigger
+{
+    bool IsReadyToTransition { set; }
+    bool RolledDouble { set; }
+    bool RolledDouble3TimesInRow { set; }
+}
+
+


### PR DESCRIPTION
This pull request is to prepare the EventStateMachine design 
```diff
- There are UML Diagrams below!
```
The current design's problem is that the event class is huge and dependent on too many classes.
I want to disassemble the event with as many pieces as the number of handlers,
and to make EventStateMachine replacing the CallNextEvent() method.

The planned structure is
- an event state machine changes its state
- an event handler observes it and conducts the event using a status handler
- the event state machine reads the state transition trigger data from the data adapter
- (not in diagram) the event would be conducted by a command invoker, and the invoker will notify the event state machine
- it is the time for the event state machine to change its state again

The brief class diagram of the current design
```mermaid
classDiagram
class Event{
-Handler1
-Handler2
-Handler3
-Handler4
-Handler5
+RollDice()
+PayRent()
+Move()
+Around20MethodsInTotal()
+CallNextEventThisIs100LinesLong()
}
Event o--> Handler1
Event o--> Handler2
Event o--> Handler3
Event o--> Handler4
Event o--> Handler5
```


The brief class diagram of the planned design
```mermaid
classDiagram
class EventStateMachine{
+CurrentActionState << enum >>ActionState
+Register(eventHandler IObserver)
}
class NormalMovingTurn{
+CurrentActionState << enum >>ActionState
+Register(eventHandler IObserver)
-TransitionFromRollingDice()
-TransitionFromMoving()
-TransitionFromActionState3()
}
class JailTurn{
+CurrentActionState << enum >>ActionState
+Register(eventHandler IObserver)
-TransitionFromActionState1()
-TransitionFromActionState2()
-TransitionFromActionState3()
}
class ActionState
<<enumeration>> ActionState
ActionState : MovingByRollDiceResultTotal
ActionState : RollingDice
ActionState : PayingRent
ActionState : GoingToJail
ActionState : MoreActions
class EventHandler1{
-boardHandler
+UpdateActionState()
+MoveByRollDiceResultTotal()
+GoToJail()
}
class IRegister
<<interface>> IRegister
IRegister : Register(observer IObserver)
class IObserver
<<interface>> IObserver
IObserver : UpdateActionState()
class DataAdapter{
+GetStateTransitionTriggerData()
}
class BoardHandler{
+Positions List< int >
+PassedGos List< bool >
+ MoveAroundBoard(playerNumber, amount)
+ Teleport(playerNumber, point)
}
IRegister <|.. EventStateMachine
EventStateMachine <|-- "*" NormalMovingTurn
EventStateMachine <|-- "*" JailTurn
NormalMovingTurn --> IObserver
JailTurn --> IObserver
EventHandler1 "*" ..|> IObserver
EventHandler1 "1" --> "1" BoardHandler
BoardHandler "*" <-- DataAdapter
EventStateMachine -->DataAdapter
```

A sequence diagram example : Execution of an action => Transition of a state => Execution of a new action
```mermaid
sequenceDiagram
Invoker->>DiceHandler : Roll
activate DiceHandler
deactivate DiceHandler
Invoker->>JailTurn : UpdateEventExecuted
activate JailTurn
JailTurn->>DataAdapter : GetRolledDoubleResult
activate DataAdapter
DataAdapter->>DiceHandler : GetRollResult
activate DiceHandler
DiceHandler-->>DataAdapter : RollResult
deactivate DiceHandler
DataAdapter-->>JailTurn : RolledDoubleResult (true)
deactivate DataAdapter
JailTurn->>JailTurn : TransitionFromRollingDice
JailTurn->>BoardEventHandler : UpdateActionState (MovingByRollDiceResultTotal)
deactivate JailTurn
BoardEventHandler->>Invoker : SetupNextCommand (MoveByRollDiceResultTotal)


```

Unfortunately, the whole change will be postponed because it is lots of work.
Nevertheless, the refactoring should be done because the current event is too big to test properly.