### PR TITLE
Refactor : made usage of TradeHandler clearer

### DIFF
--- a/Tests/EconomyHandlerTests/TradeHandlerTests.cs
+++ b/Tests/EconomyHandlerTests/TradeHandlerTests.cs
@@ -81,7 +81,7 @@ namespace Tests
             TradeHandler tradeHandler = new TradeHandler();
             List<int> participantNumbers = new List<int> {1, 2, 3, 0};
             List<Property> properties = this.CreatePropertiesPartialyOwnedByPlayer1();
-            List<int> expectedCurrentTradeOwners = new List<int> {2, 3, 0};
+            List<int> expectedSelectableTradeTargetCount = new List<int> {0, 1, 1, 1};
 
             for (int i = 0; i < 3; i++)
             {
@@ -94,14 +94,14 @@ namespace Tests
                     tradeHandler.ChangeTradeOwner();
                 }
 
-                Assert.AreEqual(tradeHandler.CurrentTradeOwner, expectedCurrentTradeOwners[i]);
+                Assert.AreEqual(tradeHandler.SelectableTargetNumbers.Count(), expectedSelectableTradeTargetCount[i]);
             }
         }
         [TestMethod]
-        public void Get_SelectableTargetNumbers_And_The_Only_Target_Is_Player1_Who_Has_Tradable_Propeerties()
+        public void Get_SelectableTargetNumbers_And_The_Only_Target_Is_Player1_Who_Has_Tradable_Properties()
         {
             TradeHandler tradeHandler = new TradeHandler();
-            List<int> participantNumbers = new List<int> {1, 2, 3, 0};
+            List<int> participantNumbers = new List<int> {0, 1, 2, 3};
             List<Property> properties = this.CreatePropertiesPartialyOwnedByPlayer1();
             tradeHandler.SetTrade(participantNumbers, properties);
 
@@ -113,7 +113,7 @@ namespace Tests
         public void SetTradeTarget_Who_Is_Selectable()
         {
             TradeHandler tradeHandler = new TradeHandler();
-            List<int> participantNumbers = new List<int> {1, 2, 3, 0};
+            List<int> participantNumbers = new List<int> {0, 1, 2, 3};
             List<Property> properties = this.CreatePropertiesPartialyOwnedByPlayer1();
             tradeHandler.SetTrade(participantNumbers, properties);
 
@@ -134,10 +134,10 @@ namespace Tests
             Assert.ThrowsException<Exception>(() => tradeHandler.SetTradeTarget(2));
         }
         [TestMethod]
-        public void SetTradeTarget_And_Get_TradablePropertiesOfTradeTarge()
+        public void SetTradeTarget_And_Get_TradablePropertiesOfTradeTarget()
         {
             TradeHandler tradeHandler = new TradeHandler();
-            List<int> participantNumbers = new List<int> {1, 2, 3, 0};
+            List<int> participantNumbers = new List<int> {0, 1, 2, 3};
             List<Property> properties = this.CreateNotOwnedProperties();
             for (int i = 0; i < 3; i++)
             {

--- a/src/ClassLibrary/Class/DecisionMaker/Interface/ITradeDecisionMaker.cs
+++ b/src/ClassLibrary/Class/DecisionMaker/Interface/ITradeDecisionMaker.cs
@@ -1,12 +1,12 @@
 public interface ITradeDecisionMaker
 {
-    public int SelectTradeTarget(int playerNumber);
+    public int SelectTradeTarget();
 
-    public IPropertyData SelectPropertyToGet(int playerNumber);
+    public int? SelectPropertyToGet();
 
-    public IPropertyData SelectPropertyToGive(int playerNumber);
+    public int? SelectPropertyToGive();
 
-    public int DecideAdditionalMoney(int playerNumber);
+    public int DecideAdditionalMoney();
 
-    public bool MakeTradeTargetDecisionOnTradeAgreement(int playerNumber);
+    public bool MakeTradeTargetDecisionOnTradeAgreement();
 }

--- a/src/ClassLibrary/Class/DecisionMaker/TradeDecisionMaker.cs
+++ b/src/ClassLibrary/Class/DecisionMaker/TradeDecisionMaker.cs
@@ -7,27 +7,27 @@ public class TradeDecisionMaker : ITradeDecisionMaker
         this.dataCenter = dataCenter;
     }
 
-    public int SelectTradeTarget(int playerNumber)
+    public int SelectTradeTarget()
     {
-        return this.dataCenter.TradeHandler.SelectableTargetNumbers[0];
+        return 0;
     }
 
-    public IPropertyData SelectPropertyToGet(int playerNumber)
+    public int? SelectPropertyToGet()
     {
-        return this.dataCenter.TradeHandler.TradablePropertiesOfTradeTarget[0];
+        return 0;
     }
 
-    public IPropertyData SelectPropertyToGive(int playerNumber)
+    public int? SelectPropertyToGive()
     {
-        return this.dataCenter.TradeHandler.TradablePropertiesOfTradeOwner[0];
+        return 0;
     }
 
-    public int DecideAdditionalMoney(int playerNumber)
+    public int DecideAdditionalMoney()
     {
         return 50;
     }
 
-    public bool MakeTradeTargetDecisionOnTradeAgreement(int playerNumber)
+    public bool MakeTradeTargetDecisionOnTradeAgreement()
     {
         return true;
     }

--- a/src/ClassLibrary/Class/EconomyHandler/Interface/ITradeHandlerData.cs
+++ b/src/ClassLibrary/Class/EconomyHandler/Interface/ITradeHandlerData.cs
@@ -8,6 +8,7 @@ public interface ITradeHandlerData
     public bool? IsTradeAgreed { get; }
     public int? CurrentTradeOwner { get; }
     public int? CurrentTradeTarget { get; }
-    public bool IsTimeToCloseTrade { get; }
+    public bool IsLastParticipant { get; }
     public List<int> SelectableTargetNumbers { get; }
+    public bool IsThereTradableProperties { get; }
 }

--- a/src/UML/TrandEventFlowChard.md
+++ b/src/UML/TrandEventFlowChard.md
@@ -1,15 +1,28 @@
 ```mermaid
 flowchart TB
-    A[MainEvent] -- MainEvent called TradeEvent --> B[StartTrade : \n starts trades from the current player]
-    B --> C[SelectTradeTarget : \n the player selects a target player]
+    A[MainEvent] --> L{there are \n tradable \n properties}
+
+    L -- No --> K
+
+    L -- Yes --> B[StartTrade : \n starts trades from the current player]
+
+    B --> M{There are \n selectable \n targets}
+    
+    M -- Yes --> C[SelectTradeTarget : \n the player selects a target player]
+
+    M -- No --> N[HasNoSelectableTarget]
+
+    N --> I
+
     C --> D[SuggestTradeOwnerTradeCondition : \n 1. a property from the target \n 2. a property from me \n 3. additional money - positive  or negative]
     D --> E[MakeTargetDecisionOnTradeAgreement : \n the target agree or disagree]
     E --> F{agreed}
-    F -- Yes --> G[DoTrade : \n exchange items]
     F -- No --> H{all player \n tried to trade}
+    F -- Yes --> G[DoTrade : \n exchange items]
+
     G --> H
     H -- No --> I[ChangeTradeOwner : \n another player can try to trade]
-    I --> C
+    I --> M
     H -- Yes --> J[EndTrade]
-    J -- Call the MainEvent --> K[MainEvent]
+    J --> K[HouseBuildingEvent]
 ```


### PR DESCRIPTION
This pull request is to make the names of methods of TradeHandler clearer
TradeEvent was refactored accordingly

see the updated flow chart

```mermaid
flowchart TB
    A[MainEvent] --> L{there are \n tradable \n properties}

    L -- No --> K

    L -- Yes --> B[StartTrade : \n starts trades from the current player]

    B --> M{There are \n selectable \n targets}
    
    M -- Yes --> C[SelectTradeTarget : \n the player selects a target player]

    M -- No --> N[HasNoSelectableTarget]

    N --> I

    C --> D[SuggestTradeOwnerTradeCondition : \n 1. a property from the target \n 2. a property from me \n 3. additional money - positive  or negative]
    D --> E[MakeTargetDecisionOnTradeAgreement : \n the target agree or disagree]
    E --> F{agreed}
    F -- No --> H{all player \n tried to trade}
    F -- Yes --> G[DoTrade : \n exchange items]

    G --> H
    H -- No --> I[ChangeTradeOwner : \n another player can try to trade]
    I --> M
    H -- Yes --> J[EndTrade]
    J --> K[HouseBuildingEvent]
```
