### PR TITLE
Uml added tile class diagram

### DIFF
--- a/Tests/EventTests/AuctionEventTests.cs
+++ b/Tests/EventTests/AuctionEventTests.cs
@@ -93,9 +93,9 @@ namespace Tests
             delegator.RunAction();
             Assert.AreEqual(delegator.NextActionName, "StartEvent");
             delegator.RunAction();
-            Assert.AreEqual(delegator.NextActionName, "DecideInitialPrice");
-            delegator.RunAction();
             Assert.AreEqual(delegator.NextActionName, "SetUpAuctionHandler");
+            delegator.RunAction();
+            Assert.AreEqual(delegator.NextActionName, "DecideInitialPrice");
             delegator.RunAction();
             Assert.AreEqual(delegator.NextActionName, "BidInTurn");
             delegator.RunAction();

--- a/Tests/EventTests/TradeEventTests.cs
+++ b/Tests/EventTests/TradeEventTests.cs
@@ -208,7 +208,7 @@ namespace Tests
             Assert.AreEqual(delegator.NextActionName, "StartEvent");
 
             delegator.RunAction();
-            Assert.AreEqual(delegator.NextActionName, "StartEvent");
+            Assert.AreEqual(delegator.NextActionName, "EndEvent");
         }
 
         [TestMethod]
@@ -223,7 +223,7 @@ namespace Tests
             Assert.AreEqual(delegator.NextActionName, "StartEvent");
 
             delegator.RunAction();
-            Assert.AreEqual(delegator.NextActionName, "StartEvent");
+            Assert.AreEqual(delegator.NextActionName, "EndEvent");
         }
         [TestMethod]
         public void StartTrade_With_TradableProperties_And_Follow_TradeEventFlow_For_OneCycle()

--- a/UML/ClassDiagrams/InterfaceSegregationClassDiagram.md
+++ b/UML/ClassDiagrams/InterfaceSegregationClassDiagram.md
@@ -1,11 +1,14 @@
 ```mermaid
 classDiagram
 class Property{
-    +string Name
     +ChangeOwnerPlayerNumber(int? playerNumber)
+}
+class Tile{
+    +string Name
 }
 class DataCenter{
     +List< ITileData > TileDatas
+    +List< IPropertyData > PropertyDatas
 }
 class IProperty{
     <<interface>>
@@ -33,4 +36,5 @@ IPropertyData --|> ITileData
 Property ..|> IProperty
 
 ITileData <-- DataCenter
+IPropertyData <-- DataCenter
 ```

--- a/UML/ClassDiagrams/InterfaceSegregationClassDiagram.md
+++ b/UML/ClassDiagrams/InterfaceSegregationClassDiagram.md
@@ -1,0 +1,36 @@
+```mermaid
+classDiagram
+class Property{
+    +string Name
+    +ChangeOwnerPlayerNumber(int? playerNumber)
+}
+class DataCenter{
+    +List< ITileData > TileDatas
+}
+class IProperty{
+    <<interface>>
+    +ChangeOwnerPlayerNumber(int? playerNumber)
+}
+class IPropertyData{
+    <<interface>>
+    +int Price
+    +int Rent
+}
+class ITile{
+    <<interface>>
+}
+class ITileData{
+    <<interface>>
+    +string Name
+}
+
+Tile ..|> ITile
+ITile --|> ITileData
+Property --|> Tile
+IProperty --|> IPropertyData
+IProperty --|> ITile
+IPropertyData --|> ITileData
+Property ..|> IProperty
+
+ITileData <-- DataCenter
+```

--- a/UML/ClassDiagrams/MonopolySummary.md
+++ b/UML/ClassDiagrams/MonopolySummary.md
@@ -1,0 +1,63 @@
+```mermaid
+classDiagram
+class Game{
+    +DataCenter Data
+    -Delegator delegator
+    -Events events
+    -Handlers handlers
+    +Run()
+}
+
+class DataCenter{
+    +HandlerDatas data
+}
+
+class Event{
+    -Events events
+    +StartEvent()
+    +CallNextAction()
+    +EndEvent()
+}
+
+class Visualizer{
+    -LoggingDrawer loggingDrawer
+    -MapDrawer mapDrawer
+    -TileDrawer tileDrawer
+    -DisplayTileInfo displayTiles
+    -PlayerStatusDrawer playerStatusDrawer
+    -DataCenter data
+}
+
+class Delegator{
+    +string NextActionName
+    +string LastActionName
+    +string NextEventName
+    +string LastEventName
+    +SetNextAction()
+    +RunAction()
+}
+
+class Handler{
+    +Data data
+    +Function1()
+    +Function2()
+}
+
+class DecisionMaker{
+    +Decide1() int
+    +Decide2() bool
+}
+
+direction TD
+Visualizer --> DataCenter
+Game *-- DataCenter
+Game *--> Delegator
+DataCenter --> Handler
+Event --> DataCenter
+Event --> Handler
+Event <--> Delegator
+direction LR
+Event --> DecisionMaker
+DecisionMaker --> DataCenter
+
+```

--- a/UML/ClassDiagrams/TileAbstractionClassDiagram.md
+++ b/UML/ClassDiagrams/TileAbstractionClassDiagram.md
@@ -1,0 +1,42 @@
+```mermaid
+classDiagram
+class Tile{
+    +string Name
+}
+class TaxTile{
+    +int Tax
+}
+class IncomeTax{
+    +int PercentageTax
+}
+class Property{
+    +int OwnerPlayerNumber
+    +int Price
+    +List<int> Rents
+    +int CurrentRent
+    +int Mortgage
+    +bool IsMortgabible
+    +bool IsSoldableWithAuction
+    +List<IProperty> Group
+    +SetGroup(List<IProperty> group)
+    +SetOwnerPlayerNumber(int? playerNumber)
+    +SetIsMortgaged(bool isMortgaged)
+}
+
+class RealEstate{
+    +BuildHouse()
+    +DistructHouse()
+}
+
+Tile <|-- FreeParking
+Tile <|-- Go
+Tile <|-- GoToJail
+Tile <|-- Jail
+Tile <|-- TaxTile
+TaxTile <|-- IncomeTax
+TaxTile <|-- LuxuryTax
+Tile <|-- Property
+Property <|-- RailRoad
+Property <|-- RealEstate
+Property <|-- Utility
+```

--- a/src/ClassLibrary/Class/Event/AuctionEvent.cs
+++ b/src/ClassLibrary/Class/Event/AuctionEvent.cs
@@ -37,7 +37,7 @@ public class AuctionEvent : Event
     public override void StartEvent()
     {
         this.eventFlow.RecommendedString = string.Format("An auction for {0} starts", this.PropertyToAuction!.Name);
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void SetUpAuction(List<int> participantNumbers, int initialPrice, IPropertyData propertyToAuction, bool firstParticipantIsForcedToBid, IEvent auctionCaller)
@@ -55,7 +55,7 @@ public class AuctionEvent : Event
 
         this.eventFlow.RecommendedString = this.CreateParticipantsString() + " joined in the auction";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void DecideInitialPrice()
@@ -70,7 +70,7 @@ public class AuctionEvent : Event
             this.eventFlow.RecommendedString = string.Format("The initial price is {0}$", this.InitialPrice);
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void BidInTurn()
@@ -86,7 +86,7 @@ public class AuctionEvent : Event
 
         this.eventFlow.RecommendedString = string.Format("Player{0} bidded {1}$", CurrentParticipantNumber, biddedPrice);
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
     private void BuyWinnerProperty()
     {
@@ -109,14 +109,14 @@ public class AuctionEvent : Event
         this.tileManager.PropertyManager.ChangeOwner(this.PropertyToAuction, winnerNumber);
 
         this.eventFlow.RecommendedString = string.Format("Player{0} bought {1}", winnerNumber, this.PropertyToAuction.Name);
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void EndAuctionWithoutAnyBid()
     {
         this.eventFlow.RecommendedString = "No one bidded";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private string CreateParticipantsString()
@@ -145,10 +145,10 @@ public class AuctionEvent : Event
     {
         this.eventFlow.RecommendedString = "This auction event is over";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
-    protected override void CallNextEvent()
+    protected override void CallNextAction()
     {
         if (this.lastAction == this.StartEvent)
         {

--- a/src/ClassLibrary/Class/Event/Event.cs
+++ b/src/ClassLibrary/Class/Event/Event.cs
@@ -25,7 +25,7 @@ public abstract class Event : IEvent
     {
         this.events = events;
     }
-    protected abstract void CallNextEvent();
+    protected abstract void CallNextAction();
     public abstract void StartEvent();
 
     public virtual void AddNextAction(Action nextAction)

--- a/src/ClassLibrary/Class/Event/HouseBuildEvent.cs
+++ b/src/ClassLibrary/Class/Event/HouseBuildEvent.cs
@@ -47,7 +47,7 @@ public class HouseBuildEvent : Event
                                                     (int)this.houseBuildHandlerData.CurrentHouseBuilder!);
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void MakeCurrentBuilderDecision()
@@ -72,7 +72,7 @@ public class HouseBuildEvent : Event
             );
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void BuildHouse()
@@ -84,7 +84,7 @@ public class HouseBuildEvent : Event
 
         this.eventFlow.RecommendedString = "A house was built";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void ChangeBuilder()
@@ -95,7 +95,7 @@ public class HouseBuildEvent : Event
                                                 "Player{0} can build a house",
                                                 (int)this.houseBuildHandlerData.CurrentHouseBuilder!);
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public override void EndEvent()
@@ -105,11 +105,11 @@ public class HouseBuildEvent : Event
             this.eventFlow.RecommendedString = "This house build event is over";
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
 
-    protected override void CallNextEvent()
+    protected override void CallNextAction()
     {
         if (this.lastAction == this.StartEvent)
         {

--- a/src/ClassLibrary/Class/Event/MainEvent.cs
+++ b/src/ClassLibrary/Class/Event/MainEvent.cs
@@ -50,7 +50,7 @@ public class MainEvent : Event, IMainEvent
 
     private string stringPlayer => String.Format("Player{0}", this.CurrentPlayerNumber);
 
-    protected override void CallNextEvent()
+    protected override void CallNextAction()
     {
         if (this.lastAction == this.StartEvent)
         {
@@ -356,7 +356,7 @@ public class MainEvent : Event, IMainEvent
 
         this.eventFlow.RecommendedString = this.stringPlayer + " rolled " + this.ConvertRollDiceResultToString();
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void PayJailFine()
@@ -365,7 +365,7 @@ public class MainEvent : Event, IMainEvent
         this.jailHandler.ResetTurnInJail(this.CurrentPlayerNumber);
         this.eventFlow.RecommendedString = this.stringPlayer + " paid the jail fine";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void PassAuctionCondition()
@@ -380,7 +380,7 @@ public class MainEvent : Event, IMainEvent
 
         this.events!.AuctionEvent.SetUpAuction(this.CreateAuctionParticipantPlayerNumbers(), initialPrice, (Property)this.GetCurrentTile(), true, this);
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void UseJailFreeCard()
@@ -389,21 +389,21 @@ public class MainEvent : Event, IMainEvent
         this.jailHandler.ResetTurnInJail(this.CurrentPlayerNumber);
         this.eventFlow.RecommendedString = this.stringPlayer + " used the jail fine";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void EscapeJail()
     {
         this.jailHandler.ResetTurnInJail(this.CurrentPlayerNumber);
         this.eventFlow.RecommendedString = this.stringPlayer + " escaped the jail";
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public override void StartEvent()
     {
         this.eventFlow.RecommendedString = this.stringPlayer + " start a turn";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void MakeDecisionOnUsageOfJailFreeCard()
@@ -418,7 +418,7 @@ public class MainEvent : Event, IMainEvent
             this.eventFlow.BoolDecision = false;
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void MakeDecisionOnPaymentOfJailFine()
@@ -431,7 +431,7 @@ public class MainEvent : Event, IMainEvent
             MakeDecisionOnPayment(this.CurrentPlayerNumber);
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void BeReleasedIfAlreadyStayed3TurnsInJail()
@@ -452,7 +452,7 @@ public class MainEvent : Event, IMainEvent
         this.jailHandler.CountTurnInJail(this.CurrentPlayerNumber);
         this.eventFlow.RecommendedString = this.stringPlayer + " stays one more turn in jail";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void IsReleasedFromJail()
@@ -469,7 +469,7 @@ public class MainEvent : Event, IMainEvent
             this.eventFlow.RecommendedString = this.stringPlayer + " is released from jail";
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void HasJailPenalty()
@@ -487,13 +487,13 @@ public class MainEvent : Event, IMainEvent
 
         this.boardHandler.Teleport(this.CurrentPlayerNumber, this.GetJailPosition());
         this.jailHandler.CountTurnInJail(this.CurrentPlayerNumber);
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void LandOnTile()
     {
         this.eventFlow.RecommendedString = this.stringPlayer + string.Format(" landed on {0}", this.currentTile.Name);
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void MoveByRollDiceResultTotal()
@@ -502,7 +502,7 @@ public class MainEvent : Event, IMainEvent
         this.eventFlow.RecommendedString = this.stringPlayer + string.Format(" moved {0} steps", rollDiceResultTotal);
 
         this.boardHandler.MovePlayerAroundBoard(this.CurrentPlayerNumber, rollDiceResultTotal);
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void PayRent()
@@ -519,7 +519,7 @@ public class MainEvent : Event, IMainEvent
         this.bankHandler.TransferBalanceFromTo(this.CurrentPlayerNumber, propertyOwner, rentOfProperty);
         this.eventFlow.RecommendedString = this.stringPlayer + string.Format(" paid {0}$ to Player{1}", rentOfProperty, propertyOwner);
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void CheckExtraTurn()
@@ -529,7 +529,7 @@ public class MainEvent : Event, IMainEvent
             this.eventFlow.RecommendedString = this.stringPlayer + " has an extra turn";
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void PayTax()
@@ -540,7 +540,7 @@ public class MainEvent : Event, IMainEvent
         this.bankHandler.DecreaseBalance(this.CurrentPlayerNumber, tax);
         this.eventFlow.RecommendedString = this.stringPlayer + " paid the tax";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void MakeDecisionOnPurchaseOfProperty()
@@ -550,7 +550,7 @@ public class MainEvent : Event, IMainEvent
         this.eventFlow.BoolDecision = this.decisionMakers.
         PropertyPurchaseDecisionMaker.MakeDecisionOnPurchase();
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void PurchaseProperty()
@@ -561,14 +561,14 @@ public class MainEvent : Event, IMainEvent
         this.bankHandler.DecreaseBalance(this.CurrentPlayerNumber, property.Price);
         this.eventFlow.RecommendedString = this.stringPlayer + " bought the property";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void DontPurchaseProperty()
     {
         this.eventFlow.RecommendedString = this.stringPlayer + " didn't buy the property";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void Idle()
@@ -576,7 +576,7 @@ public class MainEvent : Event, IMainEvent
         this.idleCount++;
         this.eventFlow.RecommendedString = string.Format("Game is idle...{0}", this.idleCount);
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public override void EndEvent()
@@ -608,7 +608,7 @@ public class MainEvent : Event, IMainEvent
             this.eventFlow.CurrentPlayerNumber = this.CalculateNextPlayer();
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void ReceiveSalary()
@@ -616,7 +616,7 @@ public class MainEvent : Event, IMainEvent
         this.eventFlow.RecommendedString = this.stringPlayer + " passed go and received the salary";
         this.bankHandler.IncreaseBalance(this.CurrentPlayerNumber, 200);
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void GameIsOver()
@@ -624,7 +624,7 @@ public class MainEvent : Event, IMainEvent
         this.eventFlow.GameIsOver = true;
         this.eventFlow.RecommendedString = "Game Is Over";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void ResetDoubleSideEffect()

--- a/src/ClassLibrary/Class/Event/SellItemEvent.cs
+++ b/src/ClassLibrary/Class/Event/SellItemEvent.cs
@@ -43,7 +43,7 @@ public class SellItemEvent : Event
 
         this.eventFlow.RecommendedString = string.Format("Player{0} needs to sell items", this.playerToSellItems);
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void MakeDecisionOnItemToSell()
@@ -69,7 +69,7 @@ public class SellItemEvent : Event
                                                     decisionString.ToLower());
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void MortgageProperty()
@@ -85,7 +85,7 @@ public class SellItemEvent : Event
                                                 this.playerToSellItems,
                                                 propertyToMortgage.Name);
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void DistructHouse()
@@ -101,12 +101,12 @@ public class SellItemEvent : Event
                                                     this.playerToSellItems,
                                                     realEstateToDistructHouse.Name);
 
-            this.CallNextEvent();
+            this.CallNextAction();
     }
 
     public void RenewSellItemEventFromAuction()
     {
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
 
@@ -124,7 +124,7 @@ public class SellItemEvent : Event
 
         this.eventFlow.RecommendedString = string.Format("Player{0} wants to auction {1}", this.playerToSellItems, propertyToAuction.Name);
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void CallAuctionEvent()
@@ -141,7 +141,7 @@ public class SellItemEvent : Event
             this.eventFlow.RecommendedString = string.Format("Player{0} needs to pay more money back", this.playerToSellItems);
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public override void EndEvent()
@@ -155,11 +155,11 @@ public class SellItemEvent : Event
             this.eventFlow.RecommendedString = string.Format("Player{0} bailed out", this.playerToSellItems);
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
 
-    protected override void CallNextEvent()
+    protected override void CallNextAction()
     {
         if (this.lastAction == this.StartEvent)
         {

--- a/src/ClassLibrary/Class/Event/TradeEvent.cs
+++ b/src/ClassLibrary/Class/Event/TradeEvent.cs
@@ -52,7 +52,7 @@ public class TradeEvent : Event
                             this.CurrentTradeOwner);
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void HasNoTradeTarget()
@@ -61,7 +61,7 @@ public class TradeEvent : Event
             string.Format("Player{0} has no selectable trade target",
                         this.CurrentTradeOwner);
         
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public void SelectTradeTarget()
@@ -84,7 +84,7 @@ public class TradeEvent : Event
                 string.Format("Player{0} skipped this trade turn", this.CurrentTradeOwner);
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void SelectTradeOwnerPropertyToGet()
@@ -99,7 +99,7 @@ public class TradeEvent : Event
 
         }
         
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void SelectTradeOwnerPropertyToGive()
@@ -113,7 +113,7 @@ public class TradeEvent : Event
                 string.Format("Player{0} is willing to give {1}", this.tradeHandler.CurrentTradeOwner, this.tradeHandler.PropertyTradeOwnerToGive!.Name);
         }
         
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void SetTradeOwnerAddicionalMoney()
@@ -144,7 +144,7 @@ public class TradeEvent : Event
                 string.Format("Player{0} is willing to give {1}$", this.tradeHandler.CurrentTradeOwner, decision);
         }
         
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void MakeTradeTargetDecisionOnTradeAgreement()
@@ -171,7 +171,7 @@ public class TradeEvent : Event
                                 this.CurrentTradeTarget);
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void DoTrade()
@@ -222,7 +222,7 @@ public class TradeEvent : Event
             .RecommendedString =
                 "Trade items were exchanged";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void ChangeTradeOwner()
@@ -239,7 +239,7 @@ public class TradeEvent : Event
                             this.CurrentTradeOwner);
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public override void EndEvent()
@@ -248,7 +248,7 @@ public class TradeEvent : Event
             .RecommendedString =
                 "All player used their trade chances";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void SetParticipantPlayerNumbers()
@@ -296,7 +296,7 @@ public class TradeEvent : Event
         return this.ConvertIntListToString(suggestedPrices.Values.ToList());
     }
 
-    protected override void CallNextEvent()
+    protected override void CallNextAction()
     {
         if (this.lastAction == this.StartEvent)
         {

--- a/src/ClassLibrary/Class/Event/UnmortgageEvent.cs
+++ b/src/ClassLibrary/Class/Event/UnmortgageEvent.cs
@@ -45,7 +45,7 @@ public class UnmortgageEvent : Event
             this.eventFlow.RecommendedString = "Players can unmortgage a property";
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void MakeCurrentPlayerDecision()
@@ -70,7 +70,7 @@ public class UnmortgageEvent : Event
             );
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void Demortgage()
@@ -83,7 +83,7 @@ public class UnmortgageEvent : Event
 
         this.eventFlow.RecommendedString = "The property is unmortgaged";
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     private void ChangePlayer()
@@ -94,7 +94,7 @@ public class UnmortgageEvent : Event
             "Player{0} can unmortgage a property",
             (int)this.unmortgageHandlerData.CurrentPlayerToDemortgage!);
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
     public override void EndEvent()
@@ -104,11 +104,11 @@ public class UnmortgageEvent : Event
             this.eventFlow.RecommendedString = "This unmortgage event is over";
         }
 
-        this.CallNextEvent();
+        this.CallNextAction();
     }
 
 
-    protected override void CallNextEvent()
+    protected override void CallNextAction()
     {
         if (this.lastAction == this.StartEvent)
         {

--- a/src/ClassLibrary/Class/Tiles/Tile/Tile.cs
+++ b/src/ClassLibrary/Class/Tiles/Tile/Tile.cs
@@ -1,4 +1,4 @@
-public class Tile : ITile, ITileData
+public class Tile : ITile
 {
     protected string name = "Tile";
 


### PR DESCRIPTION
This pull request is to add class diagrams for Tile classes

The UMLs show how the abstraction, polymorphism and interface segregations are applied to Tile classes

```mermaid
classDiagram
class Tile{
    +string Name
}
class TaxTile{
    +int Tax
}
class IncomeTax{
    +int PercentageTax
}
class Property{
    +int OwnerPlayerNumber
    +int Price
    +List<int> Rents
    +int CurrentRent
    +int Mortgage
    +bool IsMortgabible
    +bool IsSoldableWithAuction
    +List<IProperty> Group
    +SetGroup(List<IProperty> group)
    +SetOwnerPlayerNumber(int? playerNumber)
    +SetIsMortgaged(bool isMortgaged)
}

class RealEstate{
    +BuildHouse()
    +DistructHouse()
}

Tile <|-- FreeParking
Tile <|-- Go
Tile <|-- GoToJail
Tile <|-- Jail
Tile <|-- TaxTile
TaxTile <|-- IncomeTax
TaxTile <|-- LuxuryTax
Tile <|-- Property
Property <|-- RailRoad
Property <|-- RealEstate
Property <|-- Utility
```


```mermaid
classDiagram
class Property{
    +ChangeOwnerPlayerNumber(int? playerNumber)
}
class Tile{
    +string Name
}
class DataCenter{
    +List< ITileData > TileDatas
    +List< IPropertyData > PropertyDatas
}
class IProperty{
    <<interface>>
    +ChangeOwnerPlayerNumber(int? playerNumber)
}
class IPropertyData{
    <<interface>>
    +int Price
    +int Rent
}
class ITile{
    <<interface>>
}
class ITileData{
    <<interface>>
    +string Name
}

Tile ..|> ITile
ITile --|> ITileData
Property --|> Tile
IProperty --|> IPropertyData
IProperty --|> ITile
IPropertyData --|> ITileData
Property ..|> IProperty

ITileData <-- DataCenter
IPropertyData <-- DataCenter
```
